### PR TITLE
C2LC-86: Update styling and layout of the command palette

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -8,7 +8,14 @@
 }
 
 .App__command-palette {
+    background-color: #F1F1F1;
+    max-width: 20%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: space-around;
     margin-bottom: 1.5rem;
+    font-weight:bold;
 }
 
 .App__interpreter-controls {

--- a/src/App.js
+++ b/src/App.js
@@ -155,6 +155,7 @@ export default class App extends React.Component<{}, AppState> {
                     <Row className='App__mode-and-robots-section'>
                         <Col>
                             <DeviceConnectControl
+                                    bluetoothApiIsAvailable={this.appContext.bluetoothApiIsAvailable}
                                     onClickConnect={this.handleClickConnectDash}
                                     connectionStatus={this.state.dashConnectionStatus}>
                                 <FormattedMessage id='App.connectToDash' />

--- a/src/App.js
+++ b/src/App.js
@@ -1,7 +1,7 @@
 // @flow
 
 import React from 'react';
-import { injectIntl, IntlProvider, FormattedMessage } from 'react-intl';
+import { IntlProvider, FormattedMessage } from 'react-intl';
 import { Col, Container, Image, Row } from 'react-bootstrap';
 import CommandPaletteCommand from './CommandPaletteCommand';
 import DashDriver from './DashDriver';

--- a/src/App.js
+++ b/src/App.js
@@ -3,8 +3,6 @@
 import React from 'react';
 import { injectIntl, IntlProvider, FormattedMessage } from 'react-intl';
 import { Col, Container, Image, Row } from 'react-bootstrap';
-import CommandPalette from './CommandPalette';
-import CommandPaletteCategory from './CommandPaletteCategory';
 import CommandPaletteCommand from './CommandPaletteCommand';
 import DashDriver from './DashDriver';
 import DeviceConnectControl from './DeviceConnectControl';
@@ -19,8 +17,6 @@ import arrowUp from 'material-design-icons/navigation/svg/production/ic_arrow_up
 import playIcon from 'material-design-icons/av/svg/production/ic_play_arrow_48px.svg';
 import 'bootstrap/dist/css/bootstrap.min.css';
 import './App.css';
-
-const localizeProperties = (fn) => React.createElement(injectIntl(({ intl }) => fn(intl)));
 
 type AppContext = {
     bluetoothApiIsAvailable: boolean
@@ -162,37 +158,30 @@ export default class App extends React.Component<{}, AppState> {
                             </DeviceConnectControl>
                         </Col>
                     </Row>
-                    <Row className='App__program-block-editor'>
-                        <Col>
-                            <ProgramBlockEditor
-                                minVisibleSteps={6}
-                                program={this.state.program}
-                                selectedAction={this.state.selectedAction}
-                                onSelectAction={this.handleSelectAction}
-                                onChange={this.handleChangeProgram}
-                            />
+                    <Row>
+                        <Col className='App__command-palette'>
+                            <FormattedMessage id='CommandPalette.movementsTitle' />
+                            <CommandPaletteCommand commandName='forward' icon={arrowUp} selectedCommandName={this.getSelectedCommandName()} onChange={this.handleCommandFromCommandPalette}/>
+                            <CommandPaletteCommand commandName='left' icon={arrowLeft} selectedCommandName={this.getSelectedCommandName()} onChange={this.handleCommandFromCommandPalette}/>
+                            <CommandPaletteCommand commandName='right' icon={arrowRight} selectedCommandName={this.getSelectedCommandName()} onChange={this.handleCommandFromCommandPalette}/>
                         </Col>
-                        <Col>
-                            <div className='App__interpreter-controls'>
-                                <button disabled={this.state.dashConnectionStatus !== 'connected'}onClick={this.handleClickRun} aria-label={`Run current program ${this.state.program.join(' ')}`}>
-                                    <Image src={playIcon} />
-                                </button>
-                            </div>
-                        </Col>
-                    </Row>
-                    <Row className='App__command-palette'>
-                        <Col>
-                            {localizeProperties((intl) =>
-                                <CommandPalette id='commandPalette' defaultActiveKey='movements' >
-                                    <CommandPaletteCategory eventKey='movements' title={(intl.formatMessage({ id: 'CommandPalette.movementsTitle' }))}>
-                                        <CommandPaletteCommand commandName='forward' icon={arrowUp} selectedCommandName={this.getSelectedCommandName()} onChange={this.handleCommandFromCommandPalette}/>
-                                        <CommandPaletteCommand commandName='left' icon={arrowLeft} selectedCommandName={this.getSelectedCommandName()} onChange={this.handleCommandFromCommandPalette}/>
-                                        <CommandPaletteCommand commandName='right' icon={arrowRight} selectedCommandName={this.getSelectedCommandName()} onChange={this.handleCommandFromCommandPalette}/>
-                                    </CommandPaletteCategory>
-                                    <CommandPaletteCategory eventKey='sounds' title={(intl.formatMessage({ id: 'CommandPalette.soundsTitle' }))}>
-                                    </CommandPaletteCategory>
-                                </CommandPalette>
-                            )}
+                        <Col className='App__program-block-editor'>
+                            <Col>
+                                <ProgramBlockEditor
+                                    minVisibleSteps={6}
+                                    program={this.state.program}
+                                    selectedAction={this.state.selectedAction}
+                                    onSelectAction={this.handleSelectAction}
+                                    onChange={this.handleChangeProgram}
+                                />
+                            </Col>
+                            <Col>
+                                <div className='App__interpreter-controls'>
+                                    <button disabled={this.state.dashConnectionStatus !== 'connected'}onClick={this.handleClickRun} aria-label={`Run current program ${this.state.program.join(' ')}`}>
+                                        <Image src={playIcon} />
+                                    </button>
+                                </div>
+                            </Col>
                         </Col>
                     </Row>
                 </Container>

--- a/src/DeviceConnectControl.js
+++ b/src/DeviceConnectControl.js
@@ -6,6 +6,7 @@ import type {DeviceConnectionStatus} from './types';
 
 type DeviceConnectControlProps = {
     children: React.Element<any>, // Button contents
+    bluetoothApiIsAvailable: boolean,
     onClickConnect: () => void,
     connectionStatus: DeviceConnectionStatus
 };
@@ -14,7 +15,7 @@ export default class DeviceConnectControl extends React.Component<DeviceConnectC
     render() {
         return (
             <div>
-                <button onClick={this.props.onClickConnect}>{this.props.children}</button>
+                <button disabled={!this.props.bluetoothApiIsAvailable} onClick={this.props.onClickConnect}>{this.props.children}</button>
                 <FormattedMessage id={`DeviceConnectControl.${this.props.connectionStatus}`} />
             </div>
         );


### PR DESCRIPTION
- Remove tab style UI, just display commands on a Col component. 
- Update layout of components, according to 0.1 design. 
- Need to update styling when everything merges together.
- Remove localizeProperties function as well as injectIntl module since we are not injecting any text now.