### PR TITLE
C2LC-214: Fix NVDA focus issues

### DIFF
--- a/src/ActionPanel.js
+++ b/src/ActionPanel.js
@@ -143,8 +143,6 @@ class ActionPanel extends React.Component<ActionPanelProps, {}> {
                 if(optionButtonRef) {
                     optionButtonRef.focus();
                 }
-            } else {
-                element.focus();
             }
         }
     }


### PR DESCRIPTION
- Ensure that the tile element for which the ActionPanel is being
  opened does not move within the DOM by always including the
  'ProgramBlockEditor__action-panel-container-outer' element and adding
  the ActionPanel as a child of that

- Ensure that the final add node in the program editor is not
  re-rendered unnecessarily by giving it a unique stable React key
  ('endOfProgramAddNodeSection')

- Set focus when a program step is deleted (to either the step tile
  immediately following, if there is one, or the final add node)

This commit also does some refactoring and renaming to make the code
clearer.