### PR TITLE
C2LC-275: Made artifact archival stages of CI builds continue on error.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,6 +40,7 @@ jobs:
       - name: Flow Type Coverage (HTML report)
         run: npx flow-coverage-report --config .flowcoverage-all
       - name: Archive Flow Type Coverage Report
+        continue-on-error: true
         uses: actions/upload-artifact@v2
         with:
           name: Flow Type Coverage Report
@@ -47,6 +48,7 @@ jobs:
       - name: Test
         run: npm test -- --verbose --coverage
       - name: Archive Test Code Coverage Report
+        continue-on-error: true
         uses: actions/upload-artifact@v2
         with:
           name: Test Code Coverage Report


### PR DESCRIPTION
See [C2LC-275](https://issues.fluidproject.org/browse/C2LC-275) for details.