### PR TITLE
C2LC-353: Added character position control hover styles for all themes.

### DIFF
--- a/src/ProgramBlockEditor.scss
+++ b/src/ProgramBlockEditor.scss
@@ -187,6 +187,19 @@ button.btn.ProgramBlockEditor__program-deleteAll-button--pressed.ProgramBlockEdi
     stroke: #4C9990;
     width: 2.5rem;
     height: 2rem;
+
+    &:focus {
+        outline: $c2lc-focus-indicator-width solid $c2lc-focus-indicator-color;
+    }
+
+    &:hover {
+        path.filled {
+            fill: #F1AE5B;
+        }
+        path:not(.filled) {
+            stroke: #F1AE5B;
+        }
+    }
 }
 
 .ProgramBlockEditor__character-move-position-sides > svg {
@@ -199,10 +212,6 @@ button.btn.ProgramBlockEditor__program-deleteAll-button--pressed.ProgramBlockEdi
         fill: #4C9990;
         stroke: none;
     }
-}
-
-.ProgramBlockEditor__character-position-button:focus {
-    outline: $c2lc-focus-indicator-width solid $c2lc-focus-indicator-color;
 }
 
 .ProgramBlockEditor__character-position-button--disabled {

--- a/src/ProgramBlockEditor.scss
+++ b/src/ProgramBlockEditor.scss
@@ -185,7 +185,7 @@ button.btn.ProgramBlockEditor__program-deleteAll-button--pressed.ProgramBlockEdi
         outline: $c2lc-focus-indicator-width solid $c2lc-focus-indicator-color;
     }
 
-    &:hover {
+    &:not(.ProgramBlockEditor__character-position-button--disabled):hover {
         path.filled {
             fill: #F1AE5B;
         }

--- a/src/Themes.scss
+++ b/src/Themes.scss
@@ -1474,12 +1474,14 @@ body.contrast-theme {
         color: black;
     }
 
-    .ProgramBlockEditor__character-position-button:not(.ProgramBlockEditor__character-position-button--disabled) {
-        stroke: white;
-
+    .ProgramBlockEditor__character-position-button {
         &:focus {
             outline: $c2lc-focus-indicator-width solid white;
-        }
+        }        
+    }
+
+    .ProgramBlockEditor__character-position-button:not(.ProgramBlockEditor__character-position-button--disabled) {
+        stroke: white;
 
         &:hover {
             path:not(.inner):not(.filled) {

--- a/src/Themes.scss
+++ b/src/Themes.scss
@@ -780,7 +780,7 @@ body.gray-theme {
             outline: $c2lc-focus-indicator-width solid $c2lc-focus-indicator-color;
         }
     
-        &:hover {
+        &:hover:not(.ProgramBlockEditor__character-position-button--disabled) {
             path.filled {
                 fill: #505862;
 
@@ -1493,27 +1493,30 @@ body.contrast-theme {
     }
 
     .ProgramBlockEditor__character-turn-positions {
-        svg.ProgramBlockEditor__character-position-button{
+        .ProgramBlockEditor__character-position-button{
             path.filled {
                 fill: white;
+                stroke: white;
             }
         }
 
         .ProgramBlockEditor__character-position-button:not(.ProgramBlockEditor__character-position-button--disabled) path.filled {
             fill: white;
-
-       }
+        }
 
         .ProgramBlockEditor__character-position-button--disabled {
             path.filled {
                 fill: #505862;
+                stroke: #505862;
             }
         }
 
-        &:hover:not(.ProgramBlockEditor__character-position-button--disabled) {
-            path.filled {
-                fill: black;
-                stroke: white;
+        .ProgramBlockEditor__character-position-button:not(.ProgramBlockEditor__character-position-button--disabled) {
+            &:hover {
+                path.filled {
+                    fill: black;
+                    stroke: white;
+                }
             }
         }
     }

--- a/src/Themes.scss
+++ b/src/Themes.scss
@@ -719,6 +719,20 @@ body.gray-theme {
 
     .ProgramBlockEditor__character-position-button {
         stroke: #818A98;
+
+        &:focus {
+            outline: $c2lc-focus-indicator-width solid $c2lc-focus-indicator-color;
+        }
+    
+        &:hover {
+            path.filled {
+                fill: #505862;
+
+            }
+            path:not(.filled) {
+                stroke: #505862;
+            }
+        }
     }
 
     .ProgramBlockEditor__character-turn-positions {
@@ -1376,14 +1390,32 @@ body.contrast-theme {
 
     .ProgramBlockEditor__character-position-button {
         stroke: white;
+
         &:focus {
             outline: $c2lc-focus-indicator-width solid white;
         }
+
+        &:hover {
+            path:not(.inner):not(.filled) {
+                stroke: white;
+                stroke-width: 4px;
+            }
+            path.inner {
+                stroke: black;
+            }
+        }
     }
 
-    .ProgramBlockEditor__character-turn-positions {
-        svg path.filled {
+    .ProgramBlockEditor__character-turn-positions svg.ProgramBlockEditor__character-position-button{
+        path.filled {
             fill: white;
+        }
+
+        &:hover {
+            path.filled {
+                fill: black;
+                stroke: white;
+            }
         }
     }
 

--- a/src/svg/MovePositionDown.svg
+++ b/src/svg/MovePositionDown.svg
@@ -1,3 +1,18 @@
-<svg width="27" height="14" viewBox="0 0 27 14" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M2.47058 1.97083L11.3787 10.8789C12.5503 12.0505 14.4497 12.0505 15.6213 10.8789L24.5294 1.97083" stroke-width="3" stroke-linecap="round"/>
+<svg
+   xmlns="http://www.w3.org/2000/svg"
+   fill="none"
+   stroke="#000000"
+   stroke-linecap="round"
+   viewBox="0 0 27 14"
+   height="14"
+   width="27">
+  <path
+     stroke-linecap="round"
+     stroke-width="3"
+     d="M2.47058 1.97083L11.3787 10.8789C12.5503 12.0505 14.4497 12.0505 15.6213 10.8789L24.5294 1.97083" />
+  <path
+     class="inner"
+     d="M2.47058 1.97083L11.3787 10.8789C12.5503 12.0505 14.4497 12.0505 15.6213 10.8789L24.5294 1.97083"
+     stroke-width="2"
+   />
 </svg>

--- a/src/svg/MovePositionLeft.svg
+++ b/src/svg/MovePositionLeft.svg
@@ -1,3 +1,17 @@
-<svg width="14" height="27" viewBox="0 0 14 27" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M12.0294 2.47083L3.12132 11.3789C1.94975 12.5505 1.94975 14.45 3.12132 15.6216L12.0294 24.5297" stroke-width="3" stroke-linecap="round"/>
+<svg
+   xmlns="http://www.w3.org/2000/svg"
+   fill="none"
+   stroke="#0000"
+   stroke-linecap="round"
+   viewBox="0 0 14 27"
+   height="27"
+   width="14">
+  <path
+     stroke-width="3"
+     d="M 12.0294,2.47083 3.12132,11.3789 c -1.17157,1.1716 -1.17157,3.0711 0,4.2427 l 8.90808,8.9081" />
+  <path
+     class="inner"
+     d="M 12.0294,2.47083 3.12132,11.3789 c -1.17157,1.1716 -1.17157,3.0711 0,4.2427 l 8.90808,8.9081"
+     stroke-width="2"
+   />
 </svg>

--- a/src/svg/MovePositionRight.svg
+++ b/src/svg/MovePositionRight.svg
@@ -1,3 +1,18 @@
-<svg width="14" height="27" viewBox="0 0 14 27" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M1.97058 24.5297L10.8787 15.6216C12.0503 14.45 12.0503 12.5505 10.8787 11.3789L1.97058 2.47083" stroke-width="3" stroke-linecap="round"/>
+<svg
+   xmlns="http://www.w3.org/2000/svg"
+   fill="none"
+   stroke="#000000"
+   stroke-linecap="round"
+   viewBox="0 0 14 27"
+   height="27"
+   width="14">
+  <path
+     d="M1.97058 24.5297L10.8787 15.6216C12.0503 14.45 12.0503 12.5505 10.8787 11.3789L1.97058 2.47083"
+     stroke-width="3"
+   />
+  <path
+     class="inner"
+     d="M1.97058 24.5297L10.8787 15.6216C12.0503 14.45 12.0503 12.5505 10.8787 11.3789L1.97058 2.47083"
+     stroke-width="2"
+   />
 </svg>

--- a/src/svg/MovePositionUp.svg
+++ b/src/svg/MovePositionUp.svg
@@ -1,3 +1,18 @@
-<svg width="27" height="14" viewBox="0 0 27 14" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M24.5294 12.0299L15.6213 3.12181C14.4497 1.95024 12.5503 1.95023 11.3787 3.12181L2.47058 12.0299" stroke-width="3" stroke-linecap="round"/>
+<svg
+   xmlns="http://www.w3.org/2000/svg"
+   fill="none"
+   stroke="#000000"
+   stroke-linecap="round"
+   viewBox="0 0 27 14"
+   height="14"
+   width="27">
+  <path
+     stroke-width="3"
+     d="M 24.5294,12.0299 15.6213,3.12181 c -1.1716,-1.17157 -3.071,-1.17158 -4.2426,0 L 2.47058,12.0299"
+   />
+  <path
+     class="inner"
+     d="M 24.5294,12.0299 15.6213,3.12181 c -1.1716,-1.17157 -3.071,-1.17158 -4.2426,0 L 2.47058,12.0299"
+     stroke-width="2"
+   />
 </svg>


### PR DESCRIPTION
See [C2LC-353](https://issues.fluidproject.org/browse/C2LC-353) for details.

Note that the "high contrast" theme was meant to have black fill, white stroke, but that only works for the turn controls. The arrows are "stroked" shapes with no fill, if you fill them, you get a solid (and very sharply angled) triangle.  I ended up cloning the existing path superimposed on the first and reducing its stroke-width.  This "inner" path is almost always the same colour as the "outer" path.  When hovering in the high contrast theme, the "inner" path is black and the "outer" path is white, which matches the effect used with the turn buttons as closely as I could manage.