### PR TITLE
C2LC-393: Removed world icon dark background from 'mixed' theme.

### DIFF
--- a/src/Themes.scss
+++ b/src/Themes.scss
@@ -13,7 +13,6 @@ body.mixed-theme {
     }
 
     .WorldSelector .WorldIcon {
-        background-color: #30444E;
         box-shadow: inset 0 .1rem .2rem rgba(0, 0, 0, 0.5);
     }
 


### PR DESCRIPTION
See [C2LC-393](https://issues.fluidproject.org/browse/C2LC-393) for details.