### PR TITLE
C2LC-434: Run 'npm rebuild' before Netlify build

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,2 +1,4 @@
 [build]
   environment = { NODE_VERSION = "12" }
+  command = "npm run netlify-build"
+  publish = "build/"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,9 @@
         "start": "react-scripts start",
         "build": "react-scripts build",
         "test": "react-scripts test",
-        "eject": "react-scripts eject"
+        "eject": "react-scripts eject",
+        "prenetlify-build": "npm rebuild",
+        "netlify-build": "react-scripts build"
     },
     "eslintConfig": {
         "extends": "react-app",


### PR DESCRIPTION
Netlify builds are failing due to Netlify caching `node-sass` from `npm install`. When the version of Node is updated, Netlify continues to use the cached `node_modules` with the new version of Node. In the case of `node-sass`, the build done at `npm install` is Node version specific. And the caching of `node-sass` fails the build.

Example log of a failure from Netlify:

```
3:32:45 PM: $ npm run build
3:32:45 PM: > c2lc-coding-environment@0.9.0 build /opt/build/repo
3:32:45 PM: > react-scripts build
3:32:47 PM: Creating an optimized production build...
3:33:48 PM: Failed to compile.
3:33:48 PM: 
3:33:48 PM: ./src/index.scss
3:33:48 PM: Missing binding /opt/build/repo/node_modules/node-sass/vendor/linux-x64-72/binding.node
3:33:48 PM: Node Sass could not find a binding for your current environment: Linux 64-bit with Node.js 12.x
3:33:48 PM: Found bindings for the following environments:
3:33:48 PM:   - Linux 64-bit with Node.js 10.x
3:33:48 PM: This usually happens because your environment has changed since running `npm install`.
3:33:48 PM: Run `npm rebuild node-sass` to download the binding for your current environment.
```