### PR TITLE
C2LC-436: Refactor the code to handle user actions for changing the program sequence

### DIFF
--- a/.flowcoverage-tests-threshold
+++ b/.flowcoverage-tests-threshold
@@ -1,5 +1,8 @@
 {
   "concurrentFiles": 1,
+  "globExcludePatterns": [
+    "src/ProgramChangeController.test.js"
+  ],
   "globIncludePatterns": [
     "src/**/*.test.js"
   ],

--- a/src/App.js
+++ b/src/App.js
@@ -683,12 +683,12 @@ export class App extends React.Component<AppProps, AppState> {
                             break;
                         case("addCommandToEnd"):
                             if (!this.editingIsDisabled()) {
-                                // TODO: Program length could change
-                                const index = this.state.programSequence.getProgramLength();
-                                this.programChangeController.insertSelectedCommandIntoProgram(
-                                    this.programBlockEditorRef.current,
-                                    index
-                                );
+                                if (this.state.selectedAction) {
+                                    this.programChangeController.addCommandToProgramEnd(
+                                        this.programBlockEditorRef.current,
+                                        this.state.selectedAction
+                                    );
+                                }
                             }
                             break;
                         case("deleteCurrentStep"):

--- a/src/App.js
+++ b/src/App.js
@@ -512,10 +512,11 @@ export class App extends React.Component<AppProps, AppState> {
         });
     }
 
-    handleProgramBlockEditorInsertCommand = (index: number) => {
-        this.programChangeController.insertSelectedCommandIntoProgram(
+    handleProgramBlockEditorInsertSelectedAction = (index: number, selectedAction: ?string) => {
+        this.programChangeController.insertSelectedActionIntoProgram(
             this.programBlockEditorRef.current,
-            index
+            index,
+            selectedAction
         );
     }
 
@@ -675,9 +676,10 @@ export class App extends React.Component<AppProps, AppState> {
                             break;
                         case("addCommandToBeginning"):
                             if (!this.editingIsDisabled()) {
-                                this.programChangeController.insertSelectedCommandIntoProgram(
+                                this.programChangeController.insertSelectedActionIntoProgram(
                                     this.programBlockEditorRef.current,
-                                    0
+                                    0,
+                                    this.state.selectedAction
                                 );
                             }
                             break;
@@ -1164,7 +1166,7 @@ export class App extends React.Component<AppProps, AppState> {
                             addNodeExpandedMode={this.state.settings.addNodeExpandedMode}
                             world={this.state.settings.world}
                             onChangeProgramSequence={this.handleProgramSequenceChange}
-                            onInsertSelectedCommandIntoProgram={this.handleProgramBlockEditorInsertCommand}
+                            onInsertSelectedActionIntoProgram={this.handleProgramBlockEditorInsertSelectedAction}
                             onDeleteProgramStep={this.handleProgramBlockEditorDeleteStep}
                             onChangeActionPanelStepIndex={this.handleChangeActionPanelStepIndex}
                             onChangeAddNodeExpandedMode={this.handleChangeAddNodeExpandedMode}

--- a/src/App.js
+++ b/src/App.js
@@ -694,15 +694,16 @@ export class App extends React.Component<AppProps, AppState> {
                         case("deleteCurrentStep"):
                             if (!this.editingIsDisabled()) {
                                 const currentElement = document.activeElement;
-                                // $FlowFixMe: Not all elements have dataset property
-                                if (currentElement.dataset.controltype === 'programStep') {
-                                    const index = parseInt(currentElement.dataset.stepnumber, 10);
-                                    if (index != null) {
-                                        this.programChangeController.deleteProgramStep(
-                                            this.programBlockEditorRef.current,
-                                            index,
-                                            currentElement.dataset.command
-                                        );
+                                if (currentElement) {
+                                    if (currentElement.dataset.controltype === 'programStep') {
+                                        const index = parseInt(currentElement.dataset.stepnumber, 10);
+                                        if (index != null) {
+                                            this.programChangeController.deleteProgramStep(
+                                                this.programBlockEditorRef.current,
+                                                index,
+                                                currentElement.dataset.command
+                                            );
+                                        }
                                     }
                                 }
                             }
@@ -1163,10 +1164,10 @@ export class App extends React.Component<AppProps, AppState> {
                             addNodeExpandedMode={this.state.settings.addNodeExpandedMode}
                             world={this.state.settings.world}
                             onChangeProgramSequence={this.handleProgramSequenceChange}
-                            onChangeActionPanelStepIndex={this.handleChangeActionPanelStepIndex}
-                            onChangeAddNodeExpandedMode={this.handleChangeAddNodeExpandedMode}
                             onInsertSelectedCommandIntoProgram={this.handleProgramBlockEditorInsertCommand}
                             onDeleteProgramStep={this.handleProgramBlockEditorDeleteStep}
+                            onChangeActionPanelStepIndex={this.handleChangeActionPanelStepIndex}
+                            onChangeAddNodeExpandedMode={this.handleChangeAddNodeExpandedMode}
                         />
                     </div>
                     <div className='App__playAndShare-background' />

--- a/src/App.js
+++ b/src/App.js
@@ -685,12 +685,10 @@ export class App extends React.Component<AppProps, AppState> {
                             break;
                         case("addCommandToEnd"):
                             if (!this.editingIsDisabled()) {
-                                if (this.state.selectedAction) {
-                                    this.programChangeController.addCommandToProgramEnd(
-                                        this.programBlockEditorRef.current,
-                                        this.state.selectedAction
-                                    );
-                                }
+                                this.programChangeController.addSelectedActionToProgramEnd(
+                                    this.programBlockEditorRef.current,
+                                    this.state.selectedAction
+                                );
                             }
                             break;
                         case("deleteCurrentStep"):

--- a/src/ProgramBlockEditor.js
+++ b/src/ProgramBlockEditor.js
@@ -42,10 +42,10 @@ type ProgramBlockEditorProps = {
     // TODO: Remove onChangeProgramSequence once we have callbacks
     //       for each specific change
     onChangeProgramSequence: (programSequence: ProgramSequence) => void,
-    onChangeActionPanelStepIndex: (index: ?number) => void,
-    onChangeAddNodeExpandedMode: (boolean) => void,
     onInsertSelectedCommandIntoProgram: (index: number) => void,
-    onDeleteProgramStep: (index: number, command: string) => void
+    onDeleteProgramStep: (index: number, command: string) => void,
+    onChangeActionPanelStepIndex: (index: ?number) => void,
+    onChangeAddNodeExpandedMode: (boolean) => void
 };
 
 type ProgramBlockEditorState = {
@@ -55,7 +55,7 @@ type ProgramBlockEditorState = {
     closestAddNodeIndex: number
 };
 
-class ProgramBlockEditor extends React.Component<ProgramBlockEditorProps, ProgramBlockEditorState> {
+export class ProgramBlockEditor extends React.Component<ProgramBlockEditorProps, ProgramBlockEditorState> {
     commandBlockRefs: Map<number, HTMLElement>;
     addNodeRefs: Map<number, HTMLElement>;
     focusCommandBlockIndex: ?number;

--- a/src/ProgramBlockEditor.js
+++ b/src/ProgramBlockEditor.js
@@ -42,7 +42,7 @@ type ProgramBlockEditorProps = {
     // TODO: Remove onChangeProgramSequence once we have callbacks
     //       for each specific change
     onChangeProgramSequence: (programSequence: ProgramSequence) => void,
-    onInsertSelectedCommandIntoProgram: (index: number) => void,
+    onInsertSelectedActionIntoProgram: (index: number, selectedAction: ?string) => void,
     onDeleteProgramStep: (index: number, command: string) => void,
     onChangeActionPanelStepIndex: (index: ?number) => void,
     onChangeAddNodeExpandedMode: (boolean) => void
@@ -298,7 +298,8 @@ export class ProgramBlockEditor extends React.Component<ProgramBlockEditorProps,
     };
 
     handleClickAddNode = (stepNumber: number) => {
-        this.props.onInsertSelectedCommandIntoProgram(stepNumber);
+        this.props.onInsertSelectedActionIntoProgram(stepNumber,
+            this.props.selectedAction);
     };
 
     // TODO: Discuss removing this once we have a good way to test drag and drop.
@@ -365,7 +366,8 @@ export class ProgramBlockEditor extends React.Component<ProgramBlockEditorProps,
             });
 
             const closestAddNodeIndex = this.findAddNodeClosestToEvent(event);
-            this.props.onInsertSelectedCommandIntoProgram(closestAddNodeIndex);
+            this.props.onInsertSelectedActionIntoProgram(closestAddNodeIndex,
+                this.props.selectedAction);
         }
     }
 

--- a/src/ProgramBlockEditor.test.js
+++ b/src/ProgramBlockEditor.test.js
@@ -670,6 +670,55 @@ describe('Autoscroll to show a step after the active program step', () => {
     })
 });
 
+test('focusCommandBlockAfterUpdate', () => {
+    expect.assertions(3);
+
+    const mockFocus = jest.fn();
+
+    window.HTMLElement.prototype.focus = mockFocus;
+
+    const { wrapper, programBlockEditorRef } = createMountProgramBlockEditor({
+        programSequence: new ProgramSequence(['forward1', 'forward2'], 0)
+    });
+
+    // When focusCommandBlockAfterUpdate is called
+    // $FlowFixMe: Ignore that 'current' might be null -- if it is, we want the test to fail
+    programBlockEditorRef.current.focusCommandBlockAfterUpdate(1);
+
+    // And the program is updated
+    wrapper.setProps({ programSequence: new ProgramSequence(['forward1', 'forward3', 'forward2'], 0) });
+
+    // Then the program step is focused
+    expect(mockFocus.mock.calls.length).toBe(1);
+    expect(mockFocus.mock.instances.length).toBe(1);
+    expect(mockFocus.mock.instances[0]).toBe(getProgramBlockAtPosition(wrapper, 1).getDOMNode());
+});
+
+test('focusAddNodeAfterUpdate', () => {
+    expect.assertions(3);
+
+    const mockFocus = jest.fn();
+
+    window.HTMLElement.prototype.focus = mockFocus;
+
+    const { wrapper, programBlockEditorRef } = createMountProgramBlockEditor({
+        programSequence: new ProgramSequence(['forward1', 'forward2'], 0),
+        addNodeExpandedMode: true
+    });
+
+    // When focusAddNodeAfterUpdate is called
+    // $FlowFixMe: Ignore that 'current' might be null -- if it is, we want the test to fail
+    programBlockEditorRef.current.focusAddNodeAfterUpdate(1);
+
+    // And the program is updated
+    wrapper.setProps({ programSequence: new ProgramSequence(['forward1'], 0) });
+
+    // Then the add-node is focused
+    expect(mockFocus.mock.calls.length).toBe(1);
+    expect(mockFocus.mock.instances.length).toBe(1);
+    expect(mockFocus.mock.instances[0]).toBe(getAddNodeButtonAtPosition(wrapper, 1).getDOMNode());
+});
+
 test('scrollToAddNodeAfterUpdate', () => {
     expect.assertions(4);
 
@@ -684,7 +733,7 @@ test('scrollToAddNodeAfterUpdate', () => {
     });
 
     // When scrollToAddNodeAfterUpdate is called
-    // $FlowFixMe: Ignore that current might be null -- if it is, we want test to fail
+    // $FlowFixMe: Ignore that 'current' might be null -- if it is, we want the test to fail
     programBlockEditorRef.current.scrollToAddNodeAfterUpdate(6);
 
     // And the program is updated
@@ -699,7 +748,7 @@ test('scrollToAddNodeAfterUpdate', () => {
     });
     expect(mockScrollIntoView.mock.instances.length).toBe(1);
 
-    // (The index used to get the add note button position is zero because the add nodes aren't expanded).
+    // (The index used to get the add node button position is zero because the add nodes aren't expanded).
     expect(mockScrollIntoView.mock.instances[0]).toBe(getAddNodeButtonAtPosition(wrapper, 0).getDOMNode());
 });
 

--- a/src/ProgramBlockEditor.test.js
+++ b/src/ProgramBlockEditor.test.js
@@ -60,7 +60,7 @@ function createMountProgramBlockEditor(props) {
     const audioManagerMock = AudioManagerImpl.mock.instances[0];
 
     const mockChangeProgramSequenceHandler = jest.fn();
-    const mockInsertSelectedCommandIntoProgramHandler = jest.fn();
+    const mockInsertSelectedActionIntoProgramHandler = jest.fn();
     const mockDeleteProgramStepHandler = jest.fn();
     const mockChangeActionPanelStepIndex = jest.fn();
     const mockChangeAddNodeExpandedModeHandler = jest.fn();
@@ -78,7 +78,7 @@ function createMountProgramBlockEditor(props) {
                     ref: programBlockEditorRef,
                     audioManager: audioManagerInstance,
                     onChangeProgramSequence: mockChangeProgramSequenceHandler,
-                    onInsertSelectedCommandIntoProgram: mockInsertSelectedCommandIntoProgramHandler,
+                    onInsertSelectedActionIntoProgram: mockInsertSelectedActionIntoProgramHandler,
                     onDeleteProgramStep: mockDeleteProgramStepHandler,
                     onChangeActionPanelStepIndex: mockChangeActionPanelStepIndex,
                     onChangeAddNodeExpandedMode: mockChangeAddNodeExpandedModeHandler,
@@ -102,7 +102,7 @@ function createMountProgramBlockEditor(props) {
         programBlockEditorRef,
         audioManagerMock,
         mockChangeProgramSequenceHandler,
-        mockInsertSelectedCommandIntoProgramHandler,
+        mockInsertSelectedActionIntoProgramHandler,
         mockDeleteProgramStepHandler,
         mockChangeActionPanelStepIndex,
         mockChangeAddNodeExpandedModeHandler
@@ -307,11 +307,11 @@ describe('Delete All button', () => {
 });
 
 describe("Add program steps", () => {
-    test('When the add node at the end of the program is clicked, then the onInsertSelectedCommandIntoProgram callback should be called', () => {
-        expect.assertions(2);
+    test('When the add node at the end of the program is clicked, then the onInsertSelectedActionIntoProgram callback should be called', () => {
+        expect.assertions(3);
 
         // Given a program of 5 forwards and 'left45' as the selected command
-        const { wrapper, mockInsertSelectedCommandIntoProgramHandler } = createMountProgramBlockEditor({
+        const { wrapper, mockInsertSelectedActionIntoProgramHandler } = createMountProgramBlockEditor({
             programSequence: new ProgramSequence(['forward1', 'forward1', 'forward1', 'forward1', 'forward1'], 0),
             selectedAction: 'left45'
         });
@@ -321,17 +321,18 @@ describe("Add program steps", () => {
         const addNode = getAddNodeButtonAtPosition(wrapper, 0);
         addNode.simulate('click');
 
-        // Then the onInsertSelectedCommandIntoProgram callback should
-        // be called with index 5
-        expect(mockInsertSelectedCommandIntoProgramHandler.mock.calls.length).toBe(1);
-        expect(mockInsertSelectedCommandIntoProgramHandler.mock.calls[0][0]).toBe(5);
+        // Then the onInsertSelectedActionIntoProgram callback should
+        // be called with index 5 and selectedAaction 'left45'
+        expect(mockInsertSelectedActionIntoProgramHandler.mock.calls.length).toBe(1);
+        expect(mockInsertSelectedActionIntoProgramHandler.mock.calls[0][0]).toBe(5);
+        expect(mockInsertSelectedActionIntoProgramHandler.mock.calls[0][1]).toBe('left45');
     });
 
-    test('When the add node at the beginning of the program is clicked, then the onInsertSelectedCommandIntoProgram callback should be called', () => {
-        expect.assertions(2);
+    test('When the add node at the beginning of the program is clicked, then the onInsertSelectedActionIntoProgram callback should be called', () => {
+        expect.assertions(3);
 
         // Given a program of 5 forwards and 'left45' as the selected command
-        const { wrapper, mockInsertSelectedCommandIntoProgramHandler } = createMountProgramBlockEditor({
+        const { wrapper, mockInsertSelectedActionIntoProgramHandler } = createMountProgramBlockEditor({
             programSequence: new ProgramSequence(['forward1', 'forward1', 'forward1', 'forward1', 'forward1'], 0),
             selectedAction: 'left45',
             addNodeExpandedMode: true
@@ -341,17 +342,18 @@ describe("Add program steps", () => {
         const addNode = getAddNodeButtonAtPosition(wrapper, 0);
         addNode.simulate('click');
 
-        // Then the onInsertSelectedCommandIntoProgram callback should
-        // be called with index 0
-        expect(mockInsertSelectedCommandIntoProgramHandler.mock.calls.length).toBe(1);
-        expect(mockInsertSelectedCommandIntoProgramHandler.mock.calls[0][0]).toBe(0);
+        // Then the onInsertSelectedActionIntoProgram callback should
+        // be called with index 0 and selectedAaction 'left45'
+        expect(mockInsertSelectedActionIntoProgramHandler.mock.calls.length).toBe(1);
+        expect(mockInsertSelectedActionIntoProgramHandler.mock.calls[0][0]).toBe(0);
+        expect(mockInsertSelectedActionIntoProgramHandler.mock.calls[0][1]).toBe('left45');
     });
 
-    test('When an add node within the program is clicked, then the onInsertSelectedCommandIntoProgram callback should be called', () => {
-        expect.assertions(2);
+    test('When an add node within the program is clicked, then the onInsertSelectedActionIntoProgram callback should be called', () => {
+        expect.assertions(3);
 
         // Given a program of 5 forwards and 'left45' as the selected command
-        const { wrapper, mockInsertSelectedCommandIntoProgramHandler } = createMountProgramBlockEditor({
+        const { wrapper, mockInsertSelectedActionIntoProgramHandler } = createMountProgramBlockEditor({
             programSequence: new ProgramSequence(['forward1', 'forward1', 'forward1', 'forward1', 'forward1'], 0),
             selectedAction: 'left45',
             addNodeExpandedMode: true
@@ -361,10 +363,11 @@ describe("Add program steps", () => {
         const addNode = getAddNodeButtonAtPosition(wrapper, 3);
         addNode.simulate('click');
 
-        // Then the onInsertSelectedCommandIntoProgram callback should
-        // be called with index 3
-        expect(mockInsertSelectedCommandIntoProgramHandler.mock.calls.length).toBe(1);
-        expect(mockInsertSelectedCommandIntoProgramHandler.mock.calls[0][0]).toBe(3);
+        // Then the onInsertSelectedActionIntoProgram callback should
+        // be called with index 3 and selectedAaction 'left45'
+        expect(mockInsertSelectedActionIntoProgramHandler.mock.calls.length).toBe(1);
+        expect(mockInsertSelectedActionIntoProgramHandler.mock.calls[0][0]).toBe(3);
+        expect(mockInsertSelectedActionIntoProgramHandler.mock.calls[0][1]).toBe('left45');
     });
 });
 

--- a/src/ProgramChangeController.js
+++ b/src/ProgramChangeController.js
@@ -38,19 +38,21 @@ export default class ProgramChangeController {
         });
     }
 
-    // TODO: Rename to addSelectedActionToProgramEnd
-    // TODO: Test if selectedAction is set
-    addCommandToProgramEnd(programBlockEditor: ?ProgramBlockEditor,
-        command: string) {
+    addSelectedActionToProgramEnd(programBlockEditor: ?ProgramBlockEditor,
+        selectedAction: ?string) {
 
         this.app.setState((state) => {
-            this.playAnnouncementForAdd(command);
-            const index = state.programSequence.getProgramLength();
-            this.doActivitiesForAdd(programBlockEditor, index);
-            return {
-                programSequence: state.programSequence.insertStep(index,
-                    command)
-            };
+            if (selectedAction) {
+                this.playAnnouncementForAdd(selectedAction);
+                const index = state.programSequence.getProgramLength();
+                this.doActivitiesForAdd(programBlockEditor, index);
+                return {
+                    programSequence: state.programSequence.insertStep(index,
+                        selectedAction)
+                };
+            } else {
+                return {};
+            }
         });
     }
 

--- a/src/ProgramChangeController.js
+++ b/src/ProgramChangeController.js
@@ -1,0 +1,88 @@
+// @flow
+
+import type {IntlShape} from 'react-intl';
+import type {AudioManager} from './types';
+import App from './App';
+import ProgramBlockEditor from './ProgramBlockEditor';
+
+// The ProgramChangeController is responsible for making changes to the
+// App 'state.programSequence' and coordinating any user interface
+// activities associated with the change, such as making announcements,
+// setting focus, or setting up animations.
+
+export default class ProgramChangeController {
+    app: App;
+    intl: IntlShape;
+    audioManager: AudioManager;
+
+    constructor(app: App, intl: IntlShape, audioManager: AudioManager) {
+        this.app = app;
+        this.intl = intl;
+        this.audioManager = audioManager;
+    }
+
+    insertSelectedCommandIntoProgram(programBlockEditor: ProgramBlockEditor,
+        index: number) {
+
+        this.app.setState((state) => {
+            if (state.selectedAction) {
+                // Play the announcement
+                const commandString = this.intl.formatMessage({
+                    id: "Announcement." + (state.selectedAction || "")
+                });
+                this.audioManager.playAnnouncement(
+                    'add',
+                    this.intl,
+                    { command: commandString}
+                );
+
+                // Set up focus, scrolling, and animation
+                if (programBlockEditor) {
+                    programBlockEditor.focusCommandBlockAfterUpdate(index);
+                    programBlockEditor.scrollToAddNodeAfterUpdate(index + 1);
+                    programBlockEditor.setUpdatedCommandBlock(index);
+                }
+
+                return {
+                    programSequence: state.programSequence.insertStep(index,
+                        state.selectedAction)
+                };
+            } else {
+                return {};
+            }
+        });
+    }
+
+    deleteProgramStep(programBlockEditor: ProgramBlockEditor,
+        index: number, command: string) {
+
+        // TODO: Check the command
+
+        this.app.setState((state) => {
+            // Play the announcement
+            const commandString = this.intl.formatMessage({
+                id: "Announcement." + command
+            });
+            this.audioManager.playAnnouncement(
+                'delete',
+                this.intl,
+                { command: commandString }
+            );
+
+            // If there are steps following the one being deleted, focus the
+            // next step. Otherwise, focus the final add node.
+            if (programBlockEditor) {
+                if (index < state.programSequence.getProgramLength() - 1) {
+                    programBlockEditor.focusCommandBlockAfterUpdate(index);
+                } else {
+                    programBlockEditor.focusAddNodeAfterUpdate(index);
+                }
+            }
+
+            return {
+                programSequence: state.programSequence.deleteStep(index)
+            };
+        });
+    }
+
+};

--- a/src/ProgramChangeController.js
+++ b/src/ProgramChangeController.js
@@ -2,8 +2,8 @@
 
 import type {IntlShape} from 'react-intl';
 import type {AudioManager} from './types';
-import App from './App';
-import ProgramBlockEditor from './ProgramBlockEditor';
+import {App} from './App';
+import {ProgramBlockEditor} from './ProgramBlockEditor';
 
 // The ProgramChangeController is responsible for making changes to the
 // App 'state.programSequence' and coordinating any user interface
@@ -21,14 +21,16 @@ export default class ProgramChangeController {
         this.audioManager = audioManager;
     }
 
-    insertSelectedCommandIntoProgram(programBlockEditor: ProgramBlockEditor,
+    insertSelectedCommandIntoProgram(programBlockEditor: ?ProgramBlockEditor,
         index: number) {
 
         this.app.setState((state) => {
             if (state.selectedAction) {
+                const selectedAction = state.selectedAction;
+
                 // Play the announcement
                 const commandString = this.intl.formatMessage({
-                    id: "Announcement." + (state.selectedAction || "")
+                    id: "Announcement." + (selectedAction || "")
                 });
                 this.audioManager.playAnnouncement(
                     'add',
@@ -45,7 +47,7 @@ export default class ProgramChangeController {
 
                 return {
                     programSequence: state.programSequence.insertStep(index,
-                        state.selectedAction)
+                        selectedAction)
                 };
             } else {
                 return {};
@@ -53,7 +55,7 @@ export default class ProgramChangeController {
         });
     }
 
-    deleteProgramStep(programBlockEditor: ProgramBlockEditor,
+    deleteProgramStep(programBlockEditor: ?ProgramBlockEditor,
         index: number, command: string) {
 
         // TODO: Check the command

--- a/src/ProgramChangeController.js
+++ b/src/ProgramChangeController.js
@@ -21,12 +21,11 @@ export default class ProgramChangeController {
         this.audioManager = audioManager;
     }
 
-    insertSelectedCommandIntoProgram(programBlockEditor: ?ProgramBlockEditor,
-        index: number) {
+    insertSelectedActionIntoProgram(programBlockEditor: ?ProgramBlockEditor,
+        index: number, selectedAction: ?string) {
 
         this.app.setState((state) => {
-            if (state.selectedAction) {
-                const selectedAction = state.selectedAction;
+            if (selectedAction) {
                 this.playAnnouncementForAdd(selectedAction);
                 this.doActivitiesForAdd(programBlockEditor, index);
                 return {
@@ -39,6 +38,8 @@ export default class ProgramChangeController {
         });
     }
 
+    // TODO: Rename to addSelectedActionToProgramEnd
+    // TODO: Test if selectedAction is set
     addCommandToProgramEnd(programBlockEditor: ?ProgramBlockEditor,
         command: string) {
 

--- a/src/ProgramChangeController.js
+++ b/src/ProgramChangeController.js
@@ -27,24 +27,8 @@ export default class ProgramChangeController {
         this.app.setState((state) => {
             if (state.selectedAction) {
                 const selectedAction = state.selectedAction;
-
-                // Play the announcement
-                const commandString = this.intl.formatMessage({
-                    id: "Announcement." + (selectedAction || "")
-                });
-                this.audioManager.playAnnouncement(
-                    'add',
-                    this.intl,
-                    { command: commandString}
-                );
-
-                // Set up focus, scrolling, and animation
-                if (programBlockEditor) {
-                    programBlockEditor.focusCommandBlockAfterUpdate(index);
-                    programBlockEditor.scrollToAddNodeAfterUpdate(index + 1);
-                    programBlockEditor.setUpdatedCommandBlock(index);
-                }
-
+                this.playAnnouncementForAdd(selectedAction);
+                this.doActivitiesForAdd(programBlockEditor, index);
                 return {
                     programSequence: state.programSequence.insertStep(index,
                         selectedAction)
@@ -52,6 +36,20 @@ export default class ProgramChangeController {
             } else {
                 return {};
             }
+        });
+    }
+
+    addCommandToProgramEnd(programBlockEditor: ?ProgramBlockEditor,
+        command: string) {
+
+        this.app.setState((state) => {
+            this.playAnnouncementForAdd(command);
+            const index = state.programSequence.getProgramLength();
+            this.doActivitiesForAdd(programBlockEditor, index);
+            return {
+                programSequence: state.programSequence.insertStep(index,
+                    command)
+            };
         });
     }
 
@@ -85,6 +83,28 @@ export default class ProgramChangeController {
                 programSequence: state.programSequence.deleteStep(index)
             };
         });
+    }
+
+    // Internal methods
+
+    playAnnouncementForAdd(command: string) {
+        const commandString = this.intl.formatMessage({
+            id: "Announcement." + (command || "")
+        });
+        this.audioManager.playAnnouncement(
+            'add',
+            this.intl,
+            { command: commandString }
+        );
+    }
+
+    doActivitiesForAdd(programBlockEditor: ?ProgramBlockEditor, index: number) {
+        // Set up focus, scrolling, and animation
+        if (programBlockEditor) {
+            programBlockEditor.focusCommandBlockAfterUpdate(index);
+            programBlockEditor.scrollToAddNodeAfterUpdate(index + 1);
+            programBlockEditor.setUpdatedCommandBlock(index);
+        }
     }
 
 };

--- a/src/ProgramChangeController.js
+++ b/src/ProgramChangeController.js
@@ -59,32 +59,38 @@ export default class ProgramChangeController {
     deleteProgramStep(programBlockEditor: ?ProgramBlockEditor,
         index: number, command: string) {
 
-        // TODO: Check the command
-
         this.app.setState((state) => {
-            // Play the announcement
-            const commandString = this.intl.formatMessage({
-                id: "Announcement." + command
-            });
-            this.audioManager.playAnnouncement(
-                'delete',
-                this.intl,
-                { command: commandString }
-            );
+            // Check that the step to delete hasn't changed since the
+            // user made the deletion
+            if (command === state.programSequence.getProgramStepAt(index)) {
+                // Play the announcement
+                const commandString = this.intl.formatMessage({
+                    id: "Announcement." + command
+                });
+                this.audioManager.playAnnouncement(
+                    'delete',
+                    this.intl,
+                    { command: commandString }
+                );
 
-            // If there are steps following the one being deleted, focus the
-            // next step. Otherwise, focus the final add node.
-            if (programBlockEditor) {
-                if (index < state.programSequence.getProgramLength() - 1) {
-                    programBlockEditor.focusCommandBlockAfterUpdate(index);
-                } else {
-                    programBlockEditor.focusAddNodeAfterUpdate(index);
+                // If there are steps following the one being deleted, focus
+                // the next step. Otherwise, focus the final add node.
+                if (programBlockEditor) {
+                    if (index < state.programSequence.getProgramLength() - 1) {
+                        programBlockEditor.focusCommandBlockAfterUpdate(index);
+                    } else {
+                        programBlockEditor.focusAddNodeAfterUpdate(index);
+                    }
                 }
-            }
 
-            return {
-                programSequence: state.programSequence.deleteStep(index)
-            };
+                return {
+                    programSequence: state.programSequence.deleteStep(index)
+                };
+            } else {
+                // If the step to delete has changed, make no changes to the
+                // program
+                return {};
+            }
         });
     }
 

--- a/src/ProgramChangeController.test.js
+++ b/src/ProgramChangeController.test.js
@@ -39,7 +39,7 @@ function createProgramChangeController() {
     };
 }
 
-test('Given there is a selectedAction, when insertSelectedCommandIntoProgram() is called, then the program should be updated and all expected activities invoked', (done) => {
+test('Given there is a selectedAction, when insertSelectedActionIntoProgram() is called, then the program should be updated and all expected activities invoked', (done) => {
 
     expect.assertions(10);
 
@@ -47,8 +47,7 @@ test('Given there is a selectedAction, when insertSelectedCommandIntoProgram() i
 
     appMock.setState.mockImplementation((callback) => {
         const newState = callback({
-            programSequence: new ProgramSequence(['forward1', 'forward2'], 0),
-            selectedAction: 'forward3'
+            programSequence: new ProgramSequence(['forward1', 'forward2'], 0)
         });
 
         // The program should be updated
@@ -78,10 +77,11 @@ test('Given there is a selectedAction, when insertSelectedCommandIntoProgram() i
     // $FlowFixMe: Jest mock API
     ProgramBlockEditor.mockClear();
     // $FlowFixMe: Jest mock API
-    controller.insertSelectedCommandIntoProgram(new ProgramBlockEditor(), 1);
+    controller.insertSelectedActionIntoProgram(new ProgramBlockEditor(), 1,
+        'forward3');
 });
 
-test('Given there is no selectedAction, when insertSelectedCommandIntoProgram() is called, then no changes should be made', (done) => {
+test('Given there is no selectedAction, when insertSelectedActionIntoProgram() is called, then no changes should be made', (done) => {
 
     expect.assertions(5);
 
@@ -89,8 +89,7 @@ test('Given there is no selectedAction, when insertSelectedCommandIntoProgram() 
 
     appMock.setState.mockImplementation((callback) => {
         const newState = callback({
-            programSequence: new ProgramSequence([], 0),
-            selectedAction: null
+            programSequence: new ProgramSequence([], 0)
         });
 
         // The program should not be updated
@@ -112,7 +111,7 @@ test('Given there is no selectedAction, when insertSelectedCommandIntoProgram() 
     // $FlowFixMe: Jest mock API
     ProgramBlockEditor.mockClear();
     // $FlowFixMe: Jest mock API
-    controller.insertSelectedCommandIntoProgram(new ProgramBlockEditor(), 0);
+    controller.insertSelectedActionIntoProgram(new ProgramBlockEditor(), 0, null);
 });
 
 test('When addCommandToProgramEnd() is called, then the program should be updated and all expected activities invoked', (done) => {

--- a/src/ProgramChangeController.test.js
+++ b/src/ProgramChangeController.test.js
@@ -262,4 +262,36 @@ describe('Test deleteProgramStep()', () => {
         // $FlowFixMe: Jest mock API
         controller.deleteProgramStep(new ProgramBlockEditor(), 1, 'forward2');
     });
+
+    test('When the step to delete has changed, then no changes to the program should be made', (done) => {
+        expect.assertions(4);
+
+        const { controller, appMock, audioManagerMock } = createProgramChangeController();
+
+        appMock.setState.mockImplementation((callback) => {
+            const newState = callback({
+                programSequence: new ProgramSequence(['forward1', 'forward2'], 0)
+            });
+
+            // The program should not be updated
+            expect(newState).toStrictEqual({});
+
+            // No announcement should be made
+            expect(audioManagerMock.playAnnouncement.mock.calls.length).toBe(0);
+
+            // No methods on the ProgramBlockEditor should have been called
+            // $FlowFixMe: Jest mock API
+            const programBlockEditorMock = ProgramBlockEditor.mock.instances[0];
+            expect(programBlockEditorMock.focusCommandBlockAfterUpdate.mock.calls.length).toBe(0);
+            expect(programBlockEditorMock.focusAddNodeAfterUpdate.mock.calls.length).toBe(0);
+
+            done();
+        });
+
+        // $FlowFixMe: Jest mock API
+        ProgramBlockEditor.mockClear();
+        // $FlowFixMe: Jest mock API
+        controller.deleteProgramStep(new ProgramBlockEditor(), 1, 'forward3');
+    });
+
 });

--- a/src/ProgramChangeController.test.js
+++ b/src/ProgramChangeController.test.js
@@ -39,227 +39,227 @@ function createProgramChangeController() {
     };
 }
 
-test('Given there is a selectedAction, when insertSelectedActionIntoProgram() is called, then the program should be updated and all expected activities invoked', (done) => {
+describe('Test insertSelectedActionIntoProgram()', () => {
+    test('When there is a selectedAction, then the program should be updated and all expected activities invoked', (done) => {
+        expect.assertions(10);
 
-    expect.assertions(10);
+        const { controller, appMock, audioManagerMock } = createProgramChangeController();
 
-    const { controller, appMock, audioManagerMock } = createProgramChangeController();
+        appMock.setState.mockImplementation((callback) => {
+            const newState = callback({
+                programSequence: new ProgramSequence(['forward1', 'forward2'], 0)
+            });
 
-    appMock.setState.mockImplementation((callback) => {
-        const newState = callback({
-            programSequence: new ProgramSequence(['forward1', 'forward2'], 0)
+            // The program should be updated
+            expect(newState.programSequence.getProgram()).toStrictEqual(
+                ['forward1', 'forward3', 'forward2']);
+
+            // The announcement should be made
+            expect(audioManagerMock.playAnnouncement.mock.calls.length).toBe(1);
+            expect(audioManagerMock.playAnnouncement.mock.calls[0][0]).toBe('add');
+            expect(audioManagerMock.playAnnouncement.mock.calls[0][2]).toStrictEqual({
+                command: 'forward 3 squares'
+            });
+
+            // The focus, scrolling, and animation should be set up
+            // $FlowFixMe: Jest mock API
+            const programBlockEditorMock = ProgramBlockEditor.mock.instances[0];
+            expect(programBlockEditorMock.focusCommandBlockAfterUpdate.mock.calls.length).toBe(1);
+            expect(programBlockEditorMock.focusCommandBlockAfterUpdate.mock.calls[0][0]).toBe(1);
+            expect(programBlockEditorMock.scrollToAddNodeAfterUpdate.mock.calls.length).toBe(1);
+            expect(programBlockEditorMock.scrollToAddNodeAfterUpdate.mock.calls[0][0]).toBe(2);
+            expect(programBlockEditorMock.setUpdatedCommandBlock.mock.calls.length).toBe(1);
+            expect(programBlockEditorMock.setUpdatedCommandBlock.mock.calls[0][0]).toBe(1);
+
+            done();
         });
 
-        // The program should be updated
-        expect(newState.programSequence.getProgram()).toStrictEqual(
-            ['forward1', 'forward3', 'forward2']);
-
-        // The announcement should be made
-        expect(audioManagerMock.playAnnouncement.mock.calls.length).toBe(1);
-        expect(audioManagerMock.playAnnouncement.mock.calls[0][0]).toBe('add');
-        expect(audioManagerMock.playAnnouncement.mock.calls[0][2]).toStrictEqual({
-            command: 'forward 3 squares'
-        });
-
-        // The focus, scrolling, and animation should be set up
         // $FlowFixMe: Jest mock API
-        const programBlockEditorMock = ProgramBlockEditor.mock.instances[0];
-        expect(programBlockEditorMock.focusCommandBlockAfterUpdate.mock.calls.length).toBe(1);
-        expect(programBlockEditorMock.focusCommandBlockAfterUpdate.mock.calls[0][0]).toBe(1);
-        expect(programBlockEditorMock.scrollToAddNodeAfterUpdate.mock.calls.length).toBe(1);
-        expect(programBlockEditorMock.scrollToAddNodeAfterUpdate.mock.calls[0][0]).toBe(2);
-        expect(programBlockEditorMock.setUpdatedCommandBlock.mock.calls.length).toBe(1);
-        expect(programBlockEditorMock.setUpdatedCommandBlock.mock.calls[0][0]).toBe(1);
-
-        done();
+        ProgramBlockEditor.mockClear();
+        // $FlowFixMe: Jest mock API
+        controller.insertSelectedActionIntoProgram(new ProgramBlockEditor(), 1,
+            'forward3');
     });
 
-    // $FlowFixMe: Jest mock API
-    ProgramBlockEditor.mockClear();
-    // $FlowFixMe: Jest mock API
-    controller.insertSelectedActionIntoProgram(new ProgramBlockEditor(), 1,
-        'forward3');
+    test('When there is no selectedAction, then no changes should be made', (done) => {
+        expect.assertions(5);
+
+        const { controller, appMock, audioManagerMock } = createProgramChangeController();
+
+        appMock.setState.mockImplementation((callback) => {
+            const newState = callback({
+                programSequence: new ProgramSequence([], 0)
+            });
+
+            // The program should not be updated
+            expect(newState).toStrictEqual({});
+
+            // No announcement should be made
+            expect(audioManagerMock.playAnnouncement.mock.calls.length).toBe(0);
+
+            // No methods on the ProgramBlockEditor should have been called
+            // $FlowFixMe: Jest mock API
+            const programBlockEditorMock = ProgramBlockEditor.mock.instances[0];
+            expect(programBlockEditorMock.focusCommandBlockAfterUpdate.mock.calls.length).toBe(0);
+            expect(programBlockEditorMock.scrollToAddNodeAfterUpdate.mock.calls.length).toBe(0);
+            expect(programBlockEditorMock.setUpdatedCommandBlock.mock.calls.length).toBe(0);
+
+            done();
+        });
+
+        // $FlowFixMe: Jest mock API
+        ProgramBlockEditor.mockClear();
+        // $FlowFixMe: Jest mock API
+        controller.insertSelectedActionIntoProgram(new ProgramBlockEditor(), 0, null);
+    });
 });
 
-test('Given there is no selectedAction, when insertSelectedActionIntoProgram() is called, then no changes should be made', (done) => {
+describe('Test addSelectedActionToProgramEnd()', () => {
+    test('When there is a selectedAction, then the program should be updated and all expected activities invoked', (done) => {
+        expect.assertions(10);
 
-    expect.assertions(5);
+        const { controller, appMock, audioManagerMock } = createProgramChangeController();
 
-    const { controller, appMock, audioManagerMock } = createProgramChangeController();
+        appMock.setState.mockImplementation((callback) => {
+            const newState = callback({
+                programSequence: new ProgramSequence(['forward1', 'forward2'], 0)
+            });
 
-    appMock.setState.mockImplementation((callback) => {
-        const newState = callback({
-            programSequence: new ProgramSequence([], 0)
+            // The program should be updated
+            expect(newState.programSequence.getProgram()).toStrictEqual(
+                ['forward1', 'forward2', 'forward3']);
+
+            // The announcement should be made
+            expect(audioManagerMock.playAnnouncement.mock.calls.length).toBe(1);
+            expect(audioManagerMock.playAnnouncement.mock.calls[0][0]).toBe('add');
+            expect(audioManagerMock.playAnnouncement.mock.calls[0][2]).toStrictEqual({
+                command: 'forward 3 squares'
+            });
+
+            // The focus, scrolling, and animation should be set up
+            // $FlowFixMe: Jest mock API
+            const programBlockEditorMock = ProgramBlockEditor.mock.instances[0];
+            expect(programBlockEditorMock.focusCommandBlockAfterUpdate.mock.calls.length).toBe(1);
+            expect(programBlockEditorMock.focusCommandBlockAfterUpdate.mock.calls[0][0]).toBe(2);
+            expect(programBlockEditorMock.scrollToAddNodeAfterUpdate.mock.calls.length).toBe(1);
+            expect(programBlockEditorMock.scrollToAddNodeAfterUpdate.mock.calls[0][0]).toBe(3);
+            expect(programBlockEditorMock.setUpdatedCommandBlock.mock.calls.length).toBe(1);
+            expect(programBlockEditorMock.setUpdatedCommandBlock.mock.calls[0][0]).toBe(2);
+
+            done();
         });
 
-        // The program should not be updated
-        expect(newState).toStrictEqual({});
-
-        // No announcement should be made
-        expect(audioManagerMock.playAnnouncement.mock.calls.length).toBe(0);
-
-        // No methods on the ProgramBlockEditor should have been called
         // $FlowFixMe: Jest mock API
-        const programBlockEditorMock = ProgramBlockEditor.mock.instances[0];
-        expect(programBlockEditorMock.focusCommandBlockAfterUpdate.mock.calls.length).toBe(0);
-        expect(programBlockEditorMock.scrollToAddNodeAfterUpdate.mock.calls.length).toBe(0);
-        expect(programBlockEditorMock.setUpdatedCommandBlock.mock.calls.length).toBe(0);
-
-        done();
+        ProgramBlockEditor.mockClear();
+        // $FlowFixMe: Jest mock API
+        controller.addSelectedActionToProgramEnd(new ProgramBlockEditor(), 'forward3');
     });
 
-    // $FlowFixMe: Jest mock API
-    ProgramBlockEditor.mockClear();
-    // $FlowFixMe: Jest mock API
-    controller.insertSelectedActionIntoProgram(new ProgramBlockEditor(), 0, null);
+    test('When there is no selectedAction, then no changes should be made', (done) => {
+        expect.assertions(5);
+
+        const { controller, appMock, audioManagerMock } = createProgramChangeController();
+
+        appMock.setState.mockImplementation((callback) => {
+            const newState = callback({
+                programSequence: new ProgramSequence(['forward1', 'forward2'], 0)
+            });
+
+            // The program should not be updated
+            expect(newState).toStrictEqual({});
+
+            // No announcement should be made
+            expect(audioManagerMock.playAnnouncement.mock.calls.length).toBe(0);
+
+            // No methods on the ProgramBlockEditor should have been called
+            // $FlowFixMe: Jest mock API
+            const programBlockEditorMock = ProgramBlockEditor.mock.instances[0];
+            expect(programBlockEditorMock.focusCommandBlockAfterUpdate.mock.calls.length).toBe(0);
+            expect(programBlockEditorMock.scrollToAddNodeAfterUpdate.mock.calls.length).toBe(0);
+            expect(programBlockEditorMock.setUpdatedCommandBlock.mock.calls.length).toBe(0);
+
+            done();
+        });
+
+        // $FlowFixMe: Jest mock API
+        ProgramBlockEditor.mockClear();
+        // $FlowFixMe: Jest mock API
+        controller.addSelectedActionToProgramEnd(new ProgramBlockEditor(), null);
+    });
 });
 
-test('Given there is a selectedAction, when addSelectedActionToProgramEnd() is called, then the program should be updated and all expected activities invoked', (done) => {
+describe('Test deleteProgramStep()', () => {
+    test('When deleting a step not at the end, then focus is set to the step now at the deleted index', (done) => {
+        expect.assertions(7);
 
-    expect.assertions(10);
+        const { controller, appMock, audioManagerMock } = createProgramChangeController();
 
-    const { controller, appMock, audioManagerMock } = createProgramChangeController();
+        appMock.setState.mockImplementation((callback) => {
+            const newState = callback({
+                programSequence: new ProgramSequence(['forward1', 'forward2'], 0)
+            });
 
-    appMock.setState.mockImplementation((callback) => {
-        const newState = callback({
-            programSequence: new ProgramSequence(['forward1', 'forward2'], 0)
+            // The program should be updated
+            expect(newState.programSequence.getProgram()).toStrictEqual(
+                ['forward2']);
+
+            // The announcement should be made
+            expect(audioManagerMock.playAnnouncement.mock.calls.length).toBe(1);
+            expect(audioManagerMock.playAnnouncement.mock.calls[0][0]).toBe('delete');
+            expect(audioManagerMock.playAnnouncement.mock.calls[0][2]).toStrictEqual({
+                command: 'forward 1 square'
+            });
+
+            // The command block should be focused
+            // $FlowFixMe: Jest mock API
+            const programBlockEditorMock = ProgramBlockEditor.mock.instances[0];
+            expect(programBlockEditorMock.focusCommandBlockAfterUpdate.mock.calls.length).toBe(1);
+            expect(programBlockEditorMock.focusCommandBlockAfterUpdate.mock.calls[0][0]).toBe(0);
+            expect(programBlockEditorMock.focusAddNodeAfterUpdate.mock.calls.length).toBe(0);
+
+            done();
         });
 
-        // The program should be updated
-        expect(newState.programSequence.getProgram()).toStrictEqual(
-            ['forward1', 'forward2', 'forward3']);
-
-        // The announcement should be made
-        expect(audioManagerMock.playAnnouncement.mock.calls.length).toBe(1);
-        expect(audioManagerMock.playAnnouncement.mock.calls[0][0]).toBe('add');
-        expect(audioManagerMock.playAnnouncement.mock.calls[0][2]).toStrictEqual({
-            command: 'forward 3 squares'
-        });
-
-        // The focus, scrolling, and animation should be set up
         // $FlowFixMe: Jest mock API
-        const programBlockEditorMock = ProgramBlockEditor.mock.instances[0];
-        expect(programBlockEditorMock.focusCommandBlockAfterUpdate.mock.calls.length).toBe(1);
-        expect(programBlockEditorMock.focusCommandBlockAfterUpdate.mock.calls[0][0]).toBe(2);
-        expect(programBlockEditorMock.scrollToAddNodeAfterUpdate.mock.calls.length).toBe(1);
-        expect(programBlockEditorMock.scrollToAddNodeAfterUpdate.mock.calls[0][0]).toBe(3);
-        expect(programBlockEditorMock.setUpdatedCommandBlock.mock.calls.length).toBe(1);
-        expect(programBlockEditorMock.setUpdatedCommandBlock.mock.calls[0][0]).toBe(2);
-
-        done();
+        ProgramBlockEditor.mockClear();
+        // $FlowFixMe: Jest mock API
+        controller.deleteProgramStep(new ProgramBlockEditor(), 0, 'forward1');
     });
 
-    // $FlowFixMe: Jest mock API
-    ProgramBlockEditor.mockClear();
-    // $FlowFixMe: Jest mock API
-    controller.addSelectedActionToProgramEnd(new ProgramBlockEditor(), 'forward3');
-});
+    test('When deleting the step at the end, then focus is set to the add-node after the program', (done) => {
+        expect.assertions(7);
 
-test('Given there is no selectedAction, when addSelectedActionToProgramEnd() is called, then no changes should be made', (done) => {
+        const { controller, appMock, audioManagerMock } = createProgramChangeController();
 
-    expect.assertions(5);
+        appMock.setState.mockImplementation((callback) => {
+            const newState = callback({
+                programSequence: new ProgramSequence(['forward1', 'forward2'], 0)
+            });
 
-    const { controller, appMock, audioManagerMock } = createProgramChangeController();
+            // The program should be updated
+            expect(newState.programSequence.getProgram()).toStrictEqual(
+                ['forward1']);
 
-    appMock.setState.mockImplementation((callback) => {
-        const newState = callback({
-            programSequence: new ProgramSequence(['forward1', 'forward2'], 0)
+            // The announcement should be made
+            expect(audioManagerMock.playAnnouncement.mock.calls.length).toBe(1);
+            expect(audioManagerMock.playAnnouncement.mock.calls[0][0]).toBe('delete');
+            expect(audioManagerMock.playAnnouncement.mock.calls[0][2]).toStrictEqual({
+                command: 'forward 2 squares'
+            });
+
+            // The add-node after the program should be focused
+            // $FlowFixMe: Jest mock API
+            const programBlockEditorMock = ProgramBlockEditor.mock.instances[0];
+            expect(programBlockEditorMock.focusCommandBlockAfterUpdate.mock.calls.length).toBe(0);
+            expect(programBlockEditorMock.focusAddNodeAfterUpdate.mock.calls.length).toBe(1);
+            expect(programBlockEditorMock.focusAddNodeAfterUpdate.mock.calls[0][0]).toBe(1);
+
+            done();
         });
 
-        // The program should not be updated
-        expect(newState).toStrictEqual({});
-
-        // No announcement should be made
-        expect(audioManagerMock.playAnnouncement.mock.calls.length).toBe(0);
-
-        // No methods on the ProgramBlockEditor should have been called
         // $FlowFixMe: Jest mock API
-        const programBlockEditorMock = ProgramBlockEditor.mock.instances[0];
-        expect(programBlockEditorMock.focusCommandBlockAfterUpdate.mock.calls.length).toBe(0);
-        expect(programBlockEditorMock.scrollToAddNodeAfterUpdate.mock.calls.length).toBe(0);
-        expect(programBlockEditorMock.setUpdatedCommandBlock.mock.calls.length).toBe(0);
-
-        done();
-    });
-
-    // $FlowFixMe: Jest mock API
-    ProgramBlockEditor.mockClear();
-    // $FlowFixMe: Jest mock API
-    controller.addSelectedActionToProgramEnd(new ProgramBlockEditor(), null);
-});
-
-test('When deleteProgramStep() is called on a step not at the end, then focus is set to the step now at the deleted index', (done) => {
-
-    expect.assertions(7);
-
-    const { controller, appMock, audioManagerMock } = createProgramChangeController();
-
-    appMock.setState.mockImplementation((callback) => {
-        const newState = callback({
-            programSequence: new ProgramSequence(['forward1', 'forward2'], 0)
-        });
-
-        // The program should be updated
-        expect(newState.programSequence.getProgram()).toStrictEqual(
-            ['forward2']);
-
-        // The announcement should be made
-        expect(audioManagerMock.playAnnouncement.mock.calls.length).toBe(1);
-        expect(audioManagerMock.playAnnouncement.mock.calls[0][0]).toBe('delete');
-        expect(audioManagerMock.playAnnouncement.mock.calls[0][2]).toStrictEqual({
-            command: 'forward 1 square'
-        });
-
-        // The command block should be focused
+        ProgramBlockEditor.mockClear();
         // $FlowFixMe: Jest mock API
-        const programBlockEditorMock = ProgramBlockEditor.mock.instances[0];
-        expect(programBlockEditorMock.focusCommandBlockAfterUpdate.mock.calls.length).toBe(1);
-        expect(programBlockEditorMock.focusCommandBlockAfterUpdate.mock.calls[0][0]).toBe(0);
-        expect(programBlockEditorMock.focusAddNodeAfterUpdate.mock.calls.length).toBe(0);
-
-        done();
+        controller.deleteProgramStep(new ProgramBlockEditor(), 1, 'forward2');
     });
-
-    // $FlowFixMe: Jest mock API
-    ProgramBlockEditor.mockClear();
-    // $FlowFixMe: Jest mock API
-    controller.deleteProgramStep(new ProgramBlockEditor(), 0, 'forward1');
-});
-
-test('When deleteProgramStep() is called on the step at the end, then focus is set to the add-node after the program', (done) => {
-
-    expect.assertions(7);
-
-    const { controller, appMock, audioManagerMock } = createProgramChangeController();
-
-    appMock.setState.mockImplementation((callback) => {
-        const newState = callback({
-            programSequence: new ProgramSequence(['forward1', 'forward2'], 0)
-        });
-
-        // The program should be updated
-        expect(newState.programSequence.getProgram()).toStrictEqual(
-            ['forward1']);
-
-        // The announcement should be made
-        expect(audioManagerMock.playAnnouncement.mock.calls.length).toBe(1);
-        expect(audioManagerMock.playAnnouncement.mock.calls[0][0]).toBe('delete');
-        expect(audioManagerMock.playAnnouncement.mock.calls[0][2]).toStrictEqual({
-            command: 'forward 2 squares'
-        });
-
-        // The add-node after the program should be focused
-        // $FlowFixMe: Jest mock API
-        const programBlockEditorMock = ProgramBlockEditor.mock.instances[0];
-        expect(programBlockEditorMock.focusCommandBlockAfterUpdate.mock.calls.length).toBe(0);
-        expect(programBlockEditorMock.focusAddNodeAfterUpdate.mock.calls.length).toBe(1);
-        expect(programBlockEditorMock.focusAddNodeAfterUpdate.mock.calls[0][0]).toBe(1);
-
-        done();
-    });
-
-    // $FlowFixMe: Jest mock API
-    ProgramBlockEditor.mockClear();
-    // $FlowFixMe: Jest mock API
-    controller.deleteProgramStep(new ProgramBlockEditor(), 1, 'forward2');
 });

--- a/src/ProgramChangeController.test.js
+++ b/src/ProgramChangeController.test.js
@@ -114,7 +114,7 @@ test('Given there is no selectedAction, when insertSelectedActionIntoProgram() i
     controller.insertSelectedActionIntoProgram(new ProgramBlockEditor(), 0, null);
 });
 
-test('When addCommandToProgramEnd() is called, then the program should be updated and all expected activities invoked', (done) => {
+test('Given there is a selectedAction, when addSelectedActionToProgramEnd() is called, then the program should be updated and all expected activities invoked', (done) => {
 
     expect.assertions(10);
 
@@ -152,7 +152,40 @@ test('When addCommandToProgramEnd() is called, then the program should be update
     // $FlowFixMe: Jest mock API
     ProgramBlockEditor.mockClear();
     // $FlowFixMe: Jest mock API
-    controller.addCommandToProgramEnd(new ProgramBlockEditor(), 'forward3');
+    controller.addSelectedActionToProgramEnd(new ProgramBlockEditor(), 'forward3');
+});
+
+test('Given there is no selectedAction, when addSelectedActionToProgramEnd() is called, then no changes should be made', (done) => {
+
+    expect.assertions(5);
+
+    const { controller, appMock, audioManagerMock } = createProgramChangeController();
+
+    appMock.setState.mockImplementation((callback) => {
+        const newState = callback({
+            programSequence: new ProgramSequence(['forward1', 'forward2'], 0)
+        });
+
+        // The program should not be updated
+        expect(newState).toStrictEqual({});
+
+        // No announcement should be made
+        expect(audioManagerMock.playAnnouncement.mock.calls.length).toBe(0);
+
+        // No methods on the ProgramBlockEditor should have been called
+        // $FlowFixMe: Jest mock API
+        const programBlockEditorMock = ProgramBlockEditor.mock.instances[0];
+        expect(programBlockEditorMock.focusCommandBlockAfterUpdate.mock.calls.length).toBe(0);
+        expect(programBlockEditorMock.scrollToAddNodeAfterUpdate.mock.calls.length).toBe(0);
+        expect(programBlockEditorMock.setUpdatedCommandBlock.mock.calls.length).toBe(0);
+
+        done();
+    });
+
+    // $FlowFixMe: Jest mock API
+    ProgramBlockEditor.mockClear();
+    // $FlowFixMe: Jest mock API
+    controller.addSelectedActionToProgramEnd(new ProgramBlockEditor(), null);
 });
 
 test('When deleteProgramStep() is called on a step not at the end, then focus is set to the step now at the deleted index', (done) => {

--- a/src/ProgramChangeController.test.js
+++ b/src/ProgramChangeController.test.js
@@ -1,0 +1,183 @@
+// @flow
+
+import {createIntl} from 'react-intl';
+import {App} from './App';
+import AudioManagerImpl from './AudioManagerImpl';
+import {ProgramBlockEditor} from './ProgramBlockEditor';
+import ProgramChangeController from './ProgramChangeController';
+import ProgramSequence from './ProgramSequence';
+import messages from './messages.json';
+
+const intl = createIntl({
+    locale: 'en',
+    defaultLocale: 'en',
+    messages: messages.en
+});
+
+jest.mock('./App');
+jest.mock('./AudioManagerImpl');
+jest.mock('./ProgramBlockEditor');
+
+function createProgramChangeContoller() {
+    // $FlowFixMe: Jest mock API
+    App.mockClear();
+    // $FlowFixMe: Jest mock API
+    AudioManagerImpl.mockClear();
+
+    // $FlowFixMe: Jest mock API
+    const controller = new ProgramChangeController(new App(), intl, new AudioManagerImpl());
+
+    // $FlowFixMe: Jest mock API
+    const appMock = App.mock.instances[0];
+    // $FlowFixMe: Jest mock API
+    const audioManagerMock = AudioManagerImpl.mock.instances[0];
+
+    return {
+        controller,
+        appMock,
+        audioManagerMock
+    };
+}
+
+test('Given there is a selectedAction, when insertSelectedCommandIntoProgram() is called, then the program should be updated and all expected activities invoked', (done) => {
+
+    expect.assertions(9);
+
+    const { controller, appMock, audioManagerMock } = createProgramChangeContoller();
+
+    appMock.setState.mockImplementation((callback) => {
+        const newState = callback({
+            programSequence: new ProgramSequence(['forward1', 'forward2'], 0),
+            selectedAction: 'forward3'
+        });
+
+        // The program should be updated
+        expect(newState.programSequence.getProgram()).toStrictEqual(
+            ['forward1', 'forward3', 'forward2']);
+
+        // The announcement should be made
+        expect(audioManagerMock.playAnnouncement.mock.calls.length).toBe(1);
+        expect(audioManagerMock.playAnnouncement.mock.calls[0][0]).toBe('add');
+
+        // The focus, scrolling, and animation should be set up
+        // $FlowFixMe: Jest mock API
+        const programBlockEditorMock = ProgramBlockEditor.mock.instances[0];
+        expect(programBlockEditorMock.focusCommandBlockAfterUpdate.mock.calls.length).toBe(1);
+        expect(programBlockEditorMock.focusCommandBlockAfterUpdate.mock.calls[0][0]).toBe(1);
+        expect(programBlockEditorMock.scrollToAddNodeAfterUpdate.mock.calls.length).toBe(1);
+        expect(programBlockEditorMock.scrollToAddNodeAfterUpdate.mock.calls[0][0]).toBe(2);
+        expect(programBlockEditorMock.setUpdatedCommandBlock.mock.calls.length).toBe(1);
+        expect(programBlockEditorMock.setUpdatedCommandBlock.mock.calls[0][0]).toBe(1);
+
+        done();
+    });
+
+    // $FlowFixMe: Jest mock API
+    ProgramBlockEditor.mockClear();
+    // $FlowFixMe: Jest mock API
+    controller.insertSelectedCommandIntoProgram(new ProgramBlockEditor(), 1);
+});
+
+test('Given there is no selectedAction, when insertSelectedCommandIntoProgram() is called, then no changes should be made', (done) => {
+
+    expect.assertions(5);
+
+    const { controller, appMock, audioManagerMock } = createProgramChangeContoller();
+
+    appMock.setState.mockImplementation((callback) => {
+        const newState = callback({
+            programSequence: new ProgramSequence([], 0),
+            selectedAction: null
+        });
+
+        // The program should not be updated
+        expect(newState).toStrictEqual({});
+
+        // No announcement should be made
+        expect(audioManagerMock.playAnnouncement.mock.calls.length).toBe(0);
+
+        // No methods on the ProgramBlockEditor should have been called
+        // $FlowFixMe: Jest mock API
+        const programBlockEditorMock = ProgramBlockEditor.mock.instances[0];
+        expect(programBlockEditorMock.focusCommandBlockAfterUpdate.mock.calls.length).toBe(0);
+        expect(programBlockEditorMock.scrollToAddNodeAfterUpdate.mock.calls.length).toBe(0);
+        expect(programBlockEditorMock.setUpdatedCommandBlock.mock.calls.length).toBe(0);
+
+        done();
+    });
+
+    // $FlowFixMe: Jest mock API
+    ProgramBlockEditor.mockClear();
+    // $FlowFixMe: Jest mock API
+    controller.insertSelectedCommandIntoProgram(new ProgramBlockEditor(), 0);
+});
+
+test('When deleteProgramStep() is called on a step not at the end, then focus is set to the step now at the deleted index', (done) => {
+
+    expect.assertions(6);
+
+    const { controller, appMock, audioManagerMock } = createProgramChangeContoller();
+
+    appMock.setState.mockImplementation((callback) => {
+        const newState = callback({
+            programSequence: new ProgramSequence(['forward1', 'forward2'], 0)
+        });
+
+        // The program should be updated
+        expect(newState.programSequence.getProgram()).toStrictEqual(
+            ['forward2']);
+
+        // The announcement should be made
+        expect(audioManagerMock.playAnnouncement.mock.calls.length).toBe(1);
+        expect(audioManagerMock.playAnnouncement.mock.calls[0][0]).toBe('delete');
+
+        // The command block should be focused
+        // $FlowFixMe: Jest mock API
+        const programBlockEditorMock = ProgramBlockEditor.mock.instances[0];
+        expect(programBlockEditorMock.focusCommandBlockAfterUpdate.mock.calls.length).toBe(1);
+        expect(programBlockEditorMock.focusCommandBlockAfterUpdate.mock.calls[0][0]).toBe(0);
+        expect(programBlockEditorMock.focusAddNodeAfterUpdate.mock.calls.length).toBe(0);
+
+        done();
+    });
+
+    // $FlowFixMe: Jest mock API
+    ProgramBlockEditor.mockClear();
+    // $FlowFixMe: Jest mock API
+    controller.deleteProgramStep(new ProgramBlockEditor(), 0, 'forward1');
+});
+
+test('When deleteProgramStep() is called on the step at the end, then focus is set to the add-node after the program', (done) => {
+
+    expect.assertions(6);
+
+    const { controller, appMock, audioManagerMock } = createProgramChangeContoller();
+
+    appMock.setState.mockImplementation((callback) => {
+        const newState = callback({
+            programSequence: new ProgramSequence(['forward1', 'forward2'], 0)
+        });
+
+        // The program should be updated
+        expect(newState.programSequence.getProgram()).toStrictEqual(
+            ['forward1']);
+
+        // The announcement should be made
+        expect(audioManagerMock.playAnnouncement.mock.calls.length).toBe(1);
+        expect(audioManagerMock.playAnnouncement.mock.calls[0][0]).toBe('delete');
+
+        // The add-node after the program should be focused
+        // $FlowFixMe: Jest mock API
+        const programBlockEditorMock = ProgramBlockEditor.mock.instances[0];
+        expect(programBlockEditorMock.focusCommandBlockAfterUpdate.mock.calls.length).toBe(0);
+        expect(programBlockEditorMock.focusAddNodeAfterUpdate.mock.calls.length).toBe(1);
+        expect(programBlockEditorMock.focusAddNodeAfterUpdate.mock.calls[0][0]).toBe(1);
+
+        done();
+    });
+
+    // $FlowFixMe: Jest mock API
+    ProgramBlockEditor.mockClear();
+    // $FlowFixMe: Jest mock API
+    controller.deleteProgramStep(new ProgramBlockEditor(), 1, 'forward2');
+});

--- a/src/ProgramChangeController.test.js
+++ b/src/ProgramChangeController.test.js
@@ -18,7 +18,7 @@ jest.mock('./App');
 jest.mock('./AudioManagerImpl');
 jest.mock('./ProgramBlockEditor');
 
-function createProgramChangeContoller() {
+function createProgramChangeController() {
     // $FlowFixMe: Jest mock API
     App.mockClear();
     // $FlowFixMe: Jest mock API
@@ -41,9 +41,9 @@ function createProgramChangeContoller() {
 
 test('Given there is a selectedAction, when insertSelectedCommandIntoProgram() is called, then the program should be updated and all expected activities invoked', (done) => {
 
-    expect.assertions(9);
+    expect.assertions(10);
 
-    const { controller, appMock, audioManagerMock } = createProgramChangeContoller();
+    const { controller, appMock, audioManagerMock } = createProgramChangeController();
 
     appMock.setState.mockImplementation((callback) => {
         const newState = callback({
@@ -58,6 +58,9 @@ test('Given there is a selectedAction, when insertSelectedCommandIntoProgram() i
         // The announcement should be made
         expect(audioManagerMock.playAnnouncement.mock.calls.length).toBe(1);
         expect(audioManagerMock.playAnnouncement.mock.calls[0][0]).toBe('add');
+        expect(audioManagerMock.playAnnouncement.mock.calls[0][2]).toStrictEqual({
+            command: 'forward 3 squares'
+        });
 
         // The focus, scrolling, and animation should be set up
         // $FlowFixMe: Jest mock API
@@ -82,7 +85,7 @@ test('Given there is no selectedAction, when insertSelectedCommandIntoProgram() 
 
     expect.assertions(5);
 
-    const { controller, appMock, audioManagerMock } = createProgramChangeContoller();
+    const { controller, appMock, audioManagerMock } = createProgramChangeController();
 
     appMock.setState.mockImplementation((callback) => {
         const newState = callback({
@@ -112,11 +115,52 @@ test('Given there is no selectedAction, when insertSelectedCommandIntoProgram() 
     controller.insertSelectedCommandIntoProgram(new ProgramBlockEditor(), 0);
 });
 
+test('When addCommandToProgramEnd() is called, then the program should be updated and all expected activities invoked', (done) => {
+
+    expect.assertions(10);
+
+    const { controller, appMock, audioManagerMock } = createProgramChangeController();
+
+    appMock.setState.mockImplementation((callback) => {
+        const newState = callback({
+            programSequence: new ProgramSequence(['forward1', 'forward2'], 0)
+        });
+
+        // The program should be updated
+        expect(newState.programSequence.getProgram()).toStrictEqual(
+            ['forward1', 'forward2', 'forward3']);
+
+        // The announcement should be made
+        expect(audioManagerMock.playAnnouncement.mock.calls.length).toBe(1);
+        expect(audioManagerMock.playAnnouncement.mock.calls[0][0]).toBe('add');
+        expect(audioManagerMock.playAnnouncement.mock.calls[0][2]).toStrictEqual({
+            command: 'forward 3 squares'
+        });
+
+        // The focus, scrolling, and animation should be set up
+        // $FlowFixMe: Jest mock API
+        const programBlockEditorMock = ProgramBlockEditor.mock.instances[0];
+        expect(programBlockEditorMock.focusCommandBlockAfterUpdate.mock.calls.length).toBe(1);
+        expect(programBlockEditorMock.focusCommandBlockAfterUpdate.mock.calls[0][0]).toBe(2);
+        expect(programBlockEditorMock.scrollToAddNodeAfterUpdate.mock.calls.length).toBe(1);
+        expect(programBlockEditorMock.scrollToAddNodeAfterUpdate.mock.calls[0][0]).toBe(3);
+        expect(programBlockEditorMock.setUpdatedCommandBlock.mock.calls.length).toBe(1);
+        expect(programBlockEditorMock.setUpdatedCommandBlock.mock.calls[0][0]).toBe(2);
+
+        done();
+    });
+
+    // $FlowFixMe: Jest mock API
+    ProgramBlockEditor.mockClear();
+    // $FlowFixMe: Jest mock API
+    controller.addCommandToProgramEnd(new ProgramBlockEditor(), 'forward3');
+});
+
 test('When deleteProgramStep() is called on a step not at the end, then focus is set to the step now at the deleted index', (done) => {
 
-    expect.assertions(6);
+    expect.assertions(7);
 
-    const { controller, appMock, audioManagerMock } = createProgramChangeContoller();
+    const { controller, appMock, audioManagerMock } = createProgramChangeController();
 
     appMock.setState.mockImplementation((callback) => {
         const newState = callback({
@@ -130,6 +174,9 @@ test('When deleteProgramStep() is called on a step not at the end, then focus is
         // The announcement should be made
         expect(audioManagerMock.playAnnouncement.mock.calls.length).toBe(1);
         expect(audioManagerMock.playAnnouncement.mock.calls[0][0]).toBe('delete');
+        expect(audioManagerMock.playAnnouncement.mock.calls[0][2]).toStrictEqual({
+            command: 'forward 1 square'
+        });
 
         // The command block should be focused
         // $FlowFixMe: Jest mock API
@@ -149,9 +196,9 @@ test('When deleteProgramStep() is called on a step not at the end, then focus is
 
 test('When deleteProgramStep() is called on the step at the end, then focus is set to the add-node after the program', (done) => {
 
-    expect.assertions(6);
+    expect.assertions(7);
 
-    const { controller, appMock, audioManagerMock } = createProgramChangeContoller();
+    const { controller, appMock, audioManagerMock } = createProgramChangeController();
 
     appMock.setState.mockImplementation((callback) => {
         const newState = callback({
@@ -165,6 +212,9 @@ test('When deleteProgramStep() is called on the step at the end, then focus is s
         // The announcement should be made
         expect(audioManagerMock.playAnnouncement.mock.calls.length).toBe(1);
         expect(audioManagerMock.playAnnouncement.mock.calls[0][0]).toBe('delete');
+        expect(audioManagerMock.playAnnouncement.mock.calls[0][2]).toStrictEqual({
+            command: 'forward 2 squares'
+        });
 
         // The add-node after the program should be focused
         // $FlowFixMe: Jest mock API


### PR DESCRIPTION
This PR refactors the code to handle user actions for changing the program sequence (currently the interactions in the `ProgramBlockEditor` and keyboard shortcut handlers in `App`).

It introduces a new class `ProgramChangeController` which is now responsible for making changes to the `App` `state.programSequence` and coordinating any user interface activities associated with the change, such as making announcements, setting focus, or setting up animations.

Handlers for user actions for changing the program sequence now delegate to the `ProgramChangeController`, to ensure consistent user experience across different modes of access.

The details for a particular user action (index, selectedAction, step to delete, and such) are captured at the handler and then provided to the `ProgramChangeController`. With this approach, the `ProgramChangeController` can do checks, such as checking that the step to delete hasn't been replaced by another change to the program that was applied before the deletion was processed (in the case that React has batched state updates).
