### PR TITLE
Maintain focus after changing language

### DIFF
--- a/src/LanguageSelector.js
+++ b/src/LanguageSelector.js
@@ -9,23 +9,26 @@ type LanguageSelectorProps = {
     onChange: (value: LanguageTag) => void
 };
 
-export default class LanguageSelector extends React.PureComponent<LanguageSelectorProps, {}> {
-    handleClick = () => {
-        this.props.onChange(this.props.value === 'en' ? 'fr' : 'en');
-    };
+const LanguageSelector = React.forwardRef<LanguageSelectorProps, HTMLButtonElement>(
+    (props, ref) => {
+        const handleClick = () => {
+            props.onChange(props.value === 'en' ? 'fr' : 'en');
+        };
 
-    render() {
-        const label = this.props.value === 'en' ? 'Français' : 'English';
-        const labelLang = this.props.value === 'en' ? 'fr' : 'en';
+        const label = props.value === 'en' ? 'Français' : 'English';
+        const labelLang = props.value === 'en' ? 'fr' : 'en';
 
         return (
             <button
                 className='LanguageSelector'
                 lang={labelLang}
-                onClick={this.handleClick}
+                onClick={handleClick}
+                ref={ref}
             >
                 {label}
             </button>
         );
     }
-};
+);
+
+export default LanguageSelector;


### PR DESCRIPTION
Fixes #547 

* In `LanguageSelector`, use `React.forwardRef()` to enable users of `LanguageSelector` to obtain a ref to the `LanguageSelector` button
* Add 2 new instance properties to `App`: `languageSelectorRef`, a ref to the language selector (forwarded to the button, as above), and `focusLanguageSelector`, a boolean to indicate that focus should be set on the language selector
* Add a new language change handler to `App` that sets `focusLanguageSelector` when the language is changed and new code to `componentDidUpdate()` to check `focusLanguageSelector` and set focus if requested
