### PR TITLE
Clear any existing content when mounting the `CharacterAriaLive` component

### DIFF
--- a/src/CharacterAriaLive.js
+++ b/src/CharacterAriaLive.js
@@ -103,10 +103,12 @@ class CharacterAriaLive extends React.Component<CharacterAriaLiveProps, {}> {
     }
 
     componentDidMount() {
-        // Set aria-hidden
         const ariaLiveRegion = document.getElementById(this.props.ariaLiveRegionId);
         if (ariaLiveRegion) {
+            // Set aria-hidden
             ariaLiveRegion.setAttribute('aria-hidden', this.props.ariaHidden.toString());
+            // Clear any existing content (such as when we change language)
+            ariaLiveRegion.textContent = '';
         }
     }
 

--- a/src/CharacterAriaLive.test.js
+++ b/src/CharacterAriaLive.test.js
@@ -71,9 +71,20 @@ function getLiveRegionText() {
     return ((document.getElementById('someAriaLiveRegionId'): any): HTMLElement).textContent;
 }
 
+function setLiveRegionText(text: string) {
+    ((document.getElementById('someAriaLiveRegionId'): any): HTMLElement).textContent = text;
+}
+
 function getLiveRegionAriaHidden() {
     return ((document.getElementById('someAriaLiveRegionId'): any): HTMLElement).getAttribute('aria-hidden');
 }
+
+test('Existing live region content is cleared when the component is mounted', () => {
+    setLiveRegionText('content before');
+    expect(getLiveRegionText()).toBe('content before');
+    createMountCharacterAriaLive();
+    expect(getLiveRegionText()).toBe('');
+});
 
 test('The live region is updated when the characterState prop is changed', () => {
     const wrapper = createMountCharacterAriaLive();


### PR DESCRIPTION
Fixes #548

When we change language, the `CharacterAriaLive` component is remounted. This PR updates `CharacterAriaLive` to clear the content of the live region when the component is mounted.

The user experience will then be that when the language is changed, the live region will be cleared. The user won't encounter content in the previous language as the content is cleared. It won't update the last live region message to the new language, but I think this is fine as the live region is intended to present content at a particular time.
